### PR TITLE
Add message types needed for publishing.

### DIFF
--- a/src/SFA.DAS.PSRService.Messages/Events/Answers.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/Answers.cs
@@ -1,0 +1,14 @@
+﻿namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class Answers
+    {
+        public string  OrganisationName { get; set; }
+        public YourEmployees YourEmployees { get; set; }
+        public YourApprentices YourApprentices { get; set; }
+        public string FullTimeEquivalents { get; set; }
+        public string OutlineActions { get; set; }
+        public string Challenges { get; set; }
+        public string TargetPlans { get; set; }
+        public string AnythingElse { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/ReportCreated.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/ReportCreated.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using SFA.DAS.NServiceBus;
+
+namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class ReportCreated
+    : Event
+    {
+        public Guid Id { get; set; }
+        public string EmployerId { get; set; }
+        public string ReportingPeriod { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/ReportSubmitted.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/ReportSubmitted.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using SFA.DAS.NServiceBus;
+
+namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class ReportSubmitted
+    :Event
+    {
+        public Guid Id { get; set; }
+        public string EmployerId { get; set; }
+        public string ReportingPeriod { get; set; }
+        public Submitter Submitter { get; set; }
+        public Answers Answers { get; set; }
+        public ReportingPercentages ReportingPercentages { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/ReportUpdated.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/ReportUpdated.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using SFA.DAS.NServiceBus;
+
+namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class ReportUpdated
+        :Event
+    {
+        public Guid Id { get; set; }
+        public string EmployerId { get; set; }
+        public string ReportingPeriod { get; set; }
+        public Answers Answers { get; set; }
+        public ReportingPercentages ReportingPercentages { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/ReportingPercentages.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/ReportingPercentages.cs
@@ -1,0 +1,15 @@
+﻿namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class ReportingPercentages 
+    {
+        public ReportingPercentages()
+        {
+            EmploymentStarts = "0.00";
+            TotalHeadCount = "0.00";
+            NewThisPeriod = "0.00";
+        }
+        public string EmploymentStarts { get; set; }
+        public string TotalHeadCount { get; set; }
+        public string NewThisPeriod { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/Submitter.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/Submitter.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class Submitter
+    {
+        public string Name { get; set; }
+        public string Email { get; set; }
+        public string UserId { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/YourApprentices.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/YourApprentices.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class YourApprentices
+    {
+        public string AtStart { get; set; }
+        public string AtEnd { get; set; }
+        public string NewThisPeriod { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/Events/YourEmployees.cs
+++ b/src/SFA.DAS.PSRService.Messages/Events/YourEmployees.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.PSRService.Messages.Events
+{
+    public class YourEmployees
+    {
+        public string AtStart { get; set; }
+        public string AtEnd { get; set; }
+        public string NewThisPeriod { get; set; }
+    }
+}

--- a/src/SFA.DAS.PSRService.Messages/SFA.DAS.PSRService.Messages.csproj
+++ b/src/SFA.DAS.PSRService.Messages/SFA.DAS.PSRService.Messages.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>SFA.DAS.PSRService.Messages</AssemblyName>
+    <RootNamespace>SFA.DAS.PSRService.Messages</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="sfa.das.NServiceBus" Version="5.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/SFA.DAS.PSRService.sln
+++ b/src/SFA.DAS.PSRService.sln
@@ -36,6 +36,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.PSRService.Domain.U
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.PSRService.Web.Specflow.Tests", "SFA.DAS.PSRService.Web.Specflow.Tests\SFA.DAS.PSRService.Web.Specflow.Tests.csproj", "{E76F24FB-FDBF-4139-BBC7-B87FBC1453C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.PSRService.Messages", "SFA.DAS.PSRService.Messages\SFA.DAS.PSRService.Messages.csproj", "{1D08F752-0AE1-4A92-B14A-608432FB5ACC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,10 @@ Global
 		{FB3A3699-FCA9-451D-9BAF-8B3A81C71360}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB3A3699-FCA9-451D-9BAF-8B3A81C71360}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB3A3699-FCA9-451D-9BAF-8B3A81C71360}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D08F752-0AE1-4A92-B14A-608432FB5ACC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D08F752-0AE1-4A92-B14A-608432FB5ACC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D08F752-0AE1-4A92-B14A-608432FB5ACC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D08F752-0AE1-4A92-B14A-608432FB5ACC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Get message types project into master, so we can have a nuget package for this. Then we can update message publishing code (on other branches) to use the nuget package rather than project type.

These types have been developed from work on [publishing branch](https://github.com/SkillsFundingAgency/das-public-sector-reporting/tree/mpd-2035-send-messages) using a project reference.